### PR TITLE
cincinnati: bump to latest master

### DIFF
--- a/cincinnati-services/cincinnati.yaml
+++ b/cincinnati-services/cincinnati.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 06c9ce64367b55f453295b2765a9aab61791dc76
+- hash: f41ddcbffba50419a8e2273a4f942344f30c2308
   name: cincinnati
   path: /dist/openshift/cincinnati.yaml
   url: https://github.com/openshift/cincinnati


### PR DESCRIPTION
At the same time to this bump we need to change the configmap and service config to reflect the port changes of https://github.com/openshift/cincinnati/pull/65.

/cc @aditya-konarde 