### PR TITLE
cincinnati: bump to current master

### DIFF
--- a/cincinnati-services/cincinnati.yaml
+++ b/cincinnati-services/cincinnati.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 3448f6c3721f1e3c331ef7641829d5d38b1dcbd7
+- hash: 32de8cf54fb627f714657d7b9b78a4abe4f72114
   name: cincinnati
   path: /dist/openshift/cincinnati.yaml
   url: https://github.com/openshift/cincinnati


### PR DESCRIPTION
@aditya-konarde 

Before we merge this I'd like to make sure that the service configuration on production is correct.

Related PRs: 
* template update in the cincinnati codebase: https://github.com/openshift/cincinnati/pull/94
* configmap update in the app-interface repo: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/483