### PR TITLE
cincinnati: bump to current master (for PR#89)

### DIFF
--- a/cincinnati-services/cincinnati.yaml
+++ b/cincinnati-services/cincinnati.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 32de8cf54fb627f714657d7b9b78a4abe4f72114
+- hash: 951b1b7f7a2ef8612688427ac0b2162993e99894
   name: cincinnati
   path: /dist/openshift/cincinnati.yaml
   url: https://github.com/openshift/cincinnati


### PR DESCRIPTION
This updates to current master, as we landed
https://github.com/openshift/cincinnati/pull/89.

This is an out-of-cycle deployment update, in order to get
proper metrics for policy-engine.

/cc @aditya-konarde @steveeJ 