### PR TITLE
cincinnati: bump to current master (for PR#102)

### DIFF
--- a/cincinnati-services/cincinnati.yaml
+++ b/cincinnati-services/cincinnati.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 951b1b7f7a2ef8612688427ac0b2162993e99894
+- hash: bf130b71146bf1f335de64f97e4ff9c1c481b2d3
   name: cincinnati
   path: /dist/openshift/cincinnati.yaml
   url: https://github.com/openshift/cincinnati


### PR DESCRIPTION
This updates to current master, as we landed
https://github.com/openshift/cincinnati/pull/102.

This is an out-of-cycle deployment update, in order to rename the
default prefix for quay labels.

/cc @steveeJ for review