### PR TITLE
scheduled version bump

### DIFF
--- a/cincinnati-services/cincinnati.yaml
+++ b/cincinnati-services/cincinnati.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: bf130b71146bf1f335de64f97e4ff9c1c481b2d3
+- hash: 7d012126b9e79c857248b91fa41f820e299317a6
   name: cincinnati
   path: /dist/openshift/cincinnati.yaml
   url: https://github.com/openshift/cincinnati


### PR DESCRIPTION
Generated using `git log --no-merges --pretty=oneline --abbrev-commit bf130b71146bf1f335de64f97e4ff9c1c481b2d3..7d012126b9e79c857248b91fa41f820e299317a6`:

```plain
46be244 (origin/pr/edge-remove-wildcard) plugins/internal/edge_add_remove: support removal of all edges
6c61bb8 cincinnati/lib: make {next,previous}_releases() consistent with tests
ef61f02 cincinnati/lib: add previous_releases and remove_edge_* methods
f74b56f dist: update to Rust toolchain 1.34.2
49a0d80 (origin/pr/refactor-and-docstrings-and-clippy) cincinnati/lib: add missing docstrings
b947e2a cincinnati/lib: remove redundant method `add_transition`
c306312 cincinnati/lib: split remove_nodes from remove_releases
a829bfe cincinnati/plugins/internal/edge_add_remove: use generic terms in docstrings
3ec5563 *: adhere to clippy lints
d70929c cargo fmt --all
1221d80 (upstream/pr/103) docs/design/cincinnati: Remove edges instead of removing nodes
f5a6765 (upstream/pr/104) policy-engine && graph-builder: fix and switch to 2018 edition
f7be474 docs/design/cincinnati: Semantic figure names
```

/cc @shiywang @lucab what do you think of this format?